### PR TITLE
Fix theme not applied completely

### DIFF
--- a/plugin/helper.py
+++ b/plugin/helper.py
@@ -23,17 +23,24 @@ class WinTheme(object):
             return True
         else:
             return False
+ 
+    def _apply_changes(self):
+        HWND_BROADCAST = 0xFFFF
+        WM_SETTINGCHANGE = 0x1A
+        SMTO_ABORTIFHUNG = 0x0002  # Prevent hanging
+        TIMEOUT = 10
+        ctypes.windll.user32.SendMessageTimeoutW(HWND_BROADCAST, WM_SETTINGCHANGE, 0, "ImmersiveColorSet", SMTO_ABORTIFHUNG, TIMEOUT, None)
 
     def _set_system_theme(self, value):
         key = reg.OpenKey(reg.HKEY_CURRENT_USER, SUBKEY, 0, reg.KEY_ALL_ACCESS)
         reg.SetValueEx(key, "SystemUsesLightTheme", 0, reg.REG_DWORD, value)
         reg.CloseKey(key)
 
-
     def _set_app_theme(self, value):
         key = reg.OpenKey(reg.HKEY_CURRENT_USER, r"Software\Microsoft\Windows\CurrentVersion\Themes\Personalize", 0, reg.KEY_ALL_ACCESS)
         reg.SetValueEx(key, "AppsUseLightTheme", 0, reg.REG_DWORD, value)
         reg.CloseKey(key)
+        self._apply_changes()
 
     def toggle_apps_theme(self):
         if self.get_apps_theme():
@@ -46,6 +53,7 @@ class WinTheme(object):
             self._set_system_theme(OFF)
         else:
             self._set_system_theme(ON)
+        self._apply_changes()
 
     def set_dark_mode(self):
         self._set_system_theme(OFF)
@@ -60,8 +68,3 @@ class WinTheme(object):
             self.set_dark_mode()
         else:
             self.set_light_mode()
-            
-        HWND_BROADCAST = 0xFFFF
-        WM_SETTINGCHANGE = 0x1A
-        ctypes.windll.user32.SendMessageW(HWND_BROADCAST, WM_SETTINGCHANGE, 0, "ImmersiveColorSet")
-

--- a/plugin/helper.py
+++ b/plugin/helper.py
@@ -1,4 +1,5 @@
 import winreg as reg
+import ctypes
 
 ON = 1
 OFF = 0
@@ -59,3 +60,8 @@ class WinTheme(object):
             self.set_dark_mode()
         else:
             self.set_light_mode()
+            
+        HWND_BROADCAST = 0xFFFF
+        WM_SETTINGCHANGE = 0x1A
+        ctypes.windll.user32.SendMessageW(HWND_BROADCAST, WM_SETTINGCHANGE, 0, "ImmersiveColorSet")
+


### PR DESCRIPTION
Issues #7 and #4 should be solved in Windows 11 23H2 at least.

Now on every theme change a broadcast message is sent to the OS so that every app applies the changes correctly, including system parts.